### PR TITLE
feat(git): git commit linting

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,14 @@
+name: Commitlint
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    name: Commitlint
+    steps:
+      - name: Run commitlint
+        uses: opensource-nepal/commitlint@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+   - repo: https://github.com/opensource-nepal/commitlint
+     rev: v1.2.0
+     hooks:
+       - id: commitlint


### PR DESCRIPTION
enforces that git commits follows the Convetional Commits specification going forwards

commits not following the standard won't be allowed to be made

fixes #16