### PR TITLE
feat(git): go lang linting

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,0 +1,35 @@
+name: Code Linting
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+  # Replace pull_request with pull_request_target if you
+  # plan to use this action with forks, see the Limitations section
+  pull_request:
+    branches:
+      - main
+
+# Down scope as necessary via https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+permissions:
+  checks: write
+  contents: write
+
+jobs:
+  run-linters:
+    name: Run linters (Go)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      # Install your linters here
+
+      - name: Run linters
+        uses: wearerequired/lint-action@v2
+        with:
+          # Enable your linters here
+          gofmt: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,8 @@ repos:
      rev: v1.2.0
      hooks:
        - id: commitlint
+
+   - repo: https://github.com/tekwizely/pre-commit-golang
+     rev: v1.0.0-rc.1
+     hooks:
+       - id: go-fmt


### PR DESCRIPTION
pre-commit hook for gofmt and github action for checking formatting

all go code going forward should be formatted with `gofmt` before mergin with `main`

fixes #17